### PR TITLE
Fixed depreciated fortran syntax for write, added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/config.mk

--- a/src/ADFirstAidKit/debugAD.f
+++ b/src/ADFirstAidKit/debugAD.f
@@ -81,7 +81,7 @@ C DEBUG PRIMITIVES FOR THE TANGENT MODE (DIVIDED-DIFFERENCES METHOD)
       dbad_epszero = ezero
       dbad_errormax = errmax
       write (*,'("Starting TGT test, epsilon=",e7.1,
-     +     ", zero=",e7.1,", errmax=",f6.1,"%")'),
+     +     ", zero=",e7.1,", errmax=",f6.1,"%")')
      +     epsilon,ezero,(100.0*errmax)
       write (*,
      +'("===========================================================")')
@@ -585,7 +585,7 @@ C DEBUG PRIMITIVES FOR THE ADJOINT MODE, FORWARD SWEEP (DOT-PRODUCT METHOD)
       dbad_incr = incr
       dbad_nberrors = 0
       write (*,'("Starting ADJ test, zero=",e7.1,
-     +     ", errmax=",f4.1,"%, random_incr=",e8.2)'),
+     +     ", errmax=",f4.1,"%, random_incr=",e8.2)')
      +     ezero,(100.0*errmax),incr
       write (*,
      +'("===========================================================")')

--- a/src/modules/kd_tree.F90
+++ b/src/modules/kd_tree.F90
@@ -725,7 +725,7 @@ Contains
     open(unit=7, file=fileName, status='replace')
 101 format('ZONE T="Level ',I2, '"')
     do lvl=1, tp%maxDepth-1
-       write(7, 101), lvl
+       write(7, 101) lvl
        call writeLevel(tp, tp%root, lvl)
     end do
     close(7)

--- a/src/warp/verifyWarpDeriv.F90
+++ b/src/warp/verifyWarpDeriv.F90
@@ -131,7 +131,7 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
            err = (FDValue-ADValue(1))/(half*(FDValue+ADValue(1)))*100_realType
         end if
         
-        write(*, 900), 'DOF:', dof, ' OrigVal: ',orig_value(1), ' AD:', ADValue, ' FD:', &
+        write(*, 900) 'DOF:', dof, ' OrigVal: ',orig_value(1), ' AD:', ADValue, ' FD:', &
              FDValue, ' Err(%):', err
      end if
 


### PR DESCRIPTION
Syntax `write(fid,fmt), vars` has an extra comma, gives warning with GCC 7.3.0