### PR TITLE
Fixed text wrapping in tables

### DIFF
--- a/doc/_static/hgfile
+++ b/doc/_static/hgfile
@@ -1,1 +1,0 @@
-File to make hg happy

--- a/doc/_static/theme_overrides.css
+++ b/doc/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions for RTD */
+@media screen and (min-width: 767px) {
+
+    .wy-table-responsive table td {
+       /* !important prevents the common CSS stylesheets from overriding
+          this as on RTD they are loaded after this stylesheet */
+       white-space: normal !important;
+    }
+ 
+    .wy-table-responsive {
+       overflow: visible !important;
+    }
+ }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,3 +56,9 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+    ],
+}

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -3,7 +3,7 @@
 Options
 =======
 
-Here are a list of options currently available in IDWarp.
+Here are the options currently available in IDWarp.
 
 ======================================  ==========  ===========================================   ================================================================================================================================================================================
 Parameter                                  Type       Default                                       Description


### PR DESCRIPTION
## Purpose
I added the text wrapping fix for tables in the docs. This makes the options table easier to read.

## Type of change
- Documentation update