### PR TITLE
Removing CGNS support for versions older than 3.3.0

### DIFF
--- a/Common_CS.mk
+++ b/Common_CS.mk
@@ -45,7 +45,6 @@ MAKE_CLEAN_ARGUMENTS = *~ *.o *.mod *.il *.stb c_* *.so
 
 FF90_ALL_FLAGS   = -I$(MODDIR) -I. \
 		$(CGNS_INCLUDE_FLAGS) \
-		$(CGNS_VERSION_FLAG) \
 		$(FF90_GEN_FLAGS) \
 		$(FF90_OPT_FLAGS) \
 		$(PETSC_INCLUDE_FLAGS) \

--- a/Common_real.mk
+++ b/Common_real.mk
@@ -45,7 +45,6 @@ MAKE_CLEAN_ARGUMENTS = *~ *.o *.mod *.il *.stb c_* *.so
 
 FF90_ALL_FLAGS   =	-I$(MODDIR) \
 			$(CGNS_INCLUDE_FLAGS) \
-			$(CGNS_VERSION_FLAG) \
 			$(FF90_GEN_FLAGS) \
 			$(FF90_OPT_FLAGS) \
 			$(PETSC_INCLUDE_FLAGS)

--- a/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
+++ b/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
@@ -11,15 +11,9 @@ CC   = mpicc
 
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/config/defaults/config.LINUX_INTEL_OPENMPI.mk
+++ b/config/defaults/config.LINUX_INTEL_OPENMPI.mk
@@ -10,15 +10,9 @@ FF90 = mpif90
 CC   = mpicc
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/config/defaults/config.OSX_GFORTRAN_OPENMPI.mk
+++ b/config/defaults/config.OSX_GFORTRAN_OPENMPI.mk
@@ -10,15 +10,9 @@ FF90 = mpif90
 CC   = mpicc
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/idwarp/__init__.py
+++ b/idwarp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 from .UnstructuredMesh import USMesh
 from .MultiUnstructuredMesh import MultiUSMesh

--- a/src/modules/cgnsGrid.F90
+++ b/src/modules/cgnsGrid.F90
@@ -1,19 +1,12 @@
 module cgnsGrid
-  ! 
+  !
   ! A module to hold the data structures to store information related
   ! to a structured or unstructured CGNS grid
   !
   use constants
 
-#ifdef USECGNSMODULE
        use cgns
        implicit none
-#else
-       implicit none
-       include "cgnslib_f.h"
-       integer(kind=4), private :: dummyInt
-       integer, parameter :: cgsize_t=kind(dummyInt)
-#endif
 
   save
 


### PR DESCRIPTION
## Purpose
This PR removes support for the old CGNS 3.2.1 library. The code will now only support a proper fortran module. Related to this we are updating our `latest` testing images to use CGNS 4.1.2. Once merged our images test for versions 3.3.0 and 4.1.2. Users still on 3.2.1 will thus need to upgrade.

Note that a new release should be made once merged.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Testing was performed both locally and on `u20-gcc-ompi-latest`.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
