### PR TITLE
Fix MExt

### DIFF
--- a/idwarp/MExt.py
+++ b/idwarp/MExt.py
@@ -1,27 +1,28 @@
 import tempfile
-import imp
+import importlib
+from pathlib import Path
 import os
 import shutil
 import sys
 
 
-def _tmp_pkg(dir):
+def _tmp_pkg(tempDir):
     """
     Create a temporary package.
 
     Returns (name, path)
     """
     while True:
-        path = tempfile.mkdtemp(dir=dir)
+        path = tempfile.mkdtemp(dir=tempDir)
         name = os.path.basename(path)
-        try:
-            imp.find_module(name)
-            # if name is found, delete and try again
-            os.rmdir(path)
-        except:  # noqa: E722
+        spec = importlib.util.find_spec(name)
+        # None means the name was not found
+        if spec is None:
             break
-    init = open(os.path.join(path, "__init__.py"), "w")
-    init.close()
+        # if name is found, delete and try again
+        os.rmdir(path)
+    # this creates an init file so that python recognizes this as a package
+    Path(os.path.join(path, "__init__.py")).touch()
     return name, path
 
 
@@ -30,12 +31,13 @@ class MExt(object):
     Load a unique copy of a module that can be treated as a "class instance".
     """
 
-    def __init__(self, name, path=None, debug=False):
+    def __init__(self, libName, packageName, debug=False):
         tmpdir = tempfile.gettempdir()
-        self.name = name
+        self.name = libName
         self.debug = debug
         # first find the "real" module on the "real" syspath
-        srcfile, srcpath, srcdesc = imp.find_module(name, path)
+        spec = importlib.util.find_spec(packageName)
+        srcpath = os.path.join(spec.submodule_search_locations[0], f"{libName}.so")
         # now create a temp directory for the bogus package
         self._pkgname, self._pkgdir = _tmp_pkg(tmpdir)
         # copy the original module to the new package

--- a/idwarp/MExt.py
+++ b/idwarp/MExt.py
@@ -1,5 +1,5 @@
 import tempfile
-import importlib
+from importlib.util import find_spec
 from pathlib import Path
 import os
 import shutil
@@ -15,7 +15,7 @@ def _tmp_pkg(tempDir):
     while True:
         path = tempfile.mkdtemp(dir=tempDir)
         name = os.path.basename(path)
-        spec = importlib.util.find_spec(name)
+        spec = find_spec(name)
         # None means the name was not found
         if spec is None:
             break
@@ -36,7 +36,7 @@ class MExt(object):
         self.name = libName
         self.debug = debug
         # first find the "real" module on the "real" syspath
-        spec = importlib.util.find_spec(packageName)
+        spec = find_spec(packageName)
         srcpath = os.path.join(spec.submodule_search_locations[0], f"{libName}.so")
         # now create a temp directory for the bogus package
         self._pkgname, self._pkgdir = _tmp_pkg(tmpdir)

--- a/idwarp/MultiUnstructuredMesh.py
+++ b/idwarp/MultiUnstructuredMesh.py
@@ -101,8 +101,8 @@ class MultiUSMesh(object):
         try:
             self.warp
         except AttributeError:
-            curDir = os.path.dirname(os.path.realpath(__file__))
-            self.warp = MExt("idwarp", [curDir], debug=debug)._module
+            curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+            self.warp = MExt("idwarp", curDir, debug=debug)._module
 
         # Store communicator
         self.comm = comm

--- a/idwarp/MultiUnstructuredMesh_C.py
+++ b/idwarp/MultiUnstructuredMesh_C.py
@@ -28,6 +28,6 @@ class MultiUSMesh_C(MultiUSMesh):
         if "debug" in kwargs:
             debug = kwargs["debug"]
 
-        curDir = os.path.dirname(os.path.realpath(__file__))
-        self.warp = MExt.MExt("idwarp_cs", [curDir], debug=debug)._module
+        curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+        self.warp = MExt.MExt("idwarp_cs", curDir, debug=debug)._module
         MultiUSMesh.__init__(self, dtype="D", *args, **kwargs)

--- a/idwarp/UnstructuredMesh.py
+++ b/idwarp/UnstructuredMesh.py
@@ -116,8 +116,8 @@ class USMesh(BaseSolver):
         try:
             self.warp
         except AttributeError:
-            curDir = os.path.dirname(os.path.realpath(__file__))
-            self.warp = MExt("idwarp", [curDir], debug=debug)._module
+            curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+            self.warp = MExt("idwarp", curDir, debug=debug)._module
 
         # Initialize PETSc if not done so
         self.warp.initpetsc(self.comm.py2f())

--- a/idwarp/UnstructuredMesh_C.py
+++ b/idwarp/UnstructuredMesh_C.py
@@ -28,7 +28,7 @@ class USMesh_C(USMesh):
         if "debug" in kwargs:
             debug = kwargs["debug"]
 
-        curDir = os.path.dirname(os.path.realpath(__file__))
-        self.warp = MExt.MExt("idwarp_cs", [curDir], debug=debug)._module
+        curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+        self.warp = MExt.MExt("idwarp_cs", curDir, debug=debug)._module
         USMesh.__init__(self, *args, **kwargs)
         self.dtype = "D"


### PR DESCRIPTION
## Purpose
Previously `MExt` used to raise a lot of resource warnings regarding unclosed files. This PR fixes it by switching from `imp` to `importlib` since the former is deprecated. I also made some other minor adjustments to the code to improve readability/code quality.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Code that runs IDwarp will not receive `ResourceWarning` anymore.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
