### PR TITLE
Add compatibility with latest PETSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ src/f2py/libidwarp-f2pywrappers2.f90
 src_cs/f2py/libidwarp_cs-f2pywrappers2.f90
 src_cs/f2py/get_f2py.py
 idwarp.egg-info
+input_files/*/
+input_files/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ src_cs/f2py/get_f2py.py
 idwarp.egg-info
 input_files/*/
 input_files/*.tar.gz
+testflo_report.out

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ src/f2py/libidwarp.pyf.autogen
 src/f2py/libidwarp-f2pywrappers2.f90
 src_cs/f2py/libidwarp_cs-f2pywrappers2.f90
 src_cs/f2py/get_f2py.py
+idwarp.egg-info

--- a/src/warp/getSurfaceCoordinates.F90
+++ b/src/warp/getSurfaceCoordinates.F90
@@ -1,5 +1,6 @@
 subroutine getSurfaceCoordinates(coordinates, cdof)
 
+#include <petscversion.h>
   use gridData
   implicit none
 
@@ -17,8 +18,12 @@ subroutine getSurfaceCoordinates(coordinates, cdof)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, cdof
-     call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
-     call EChk(ierr, __FILE__, __LINE__)
+#if PETSC_VERSION_MINOR > 13
+      call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
+#else
+      call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)
+#endif
+    call EChk(ierr, __FILE__, __LINE__)
   end do
 
 end subroutine getSurfaceCoordinates

--- a/src/warp/getSurfaceCoordinates.F90
+++ b/src/warp/getSurfaceCoordinates.F90
@@ -2,22 +2,22 @@ subroutine getSurfaceCoordinates(coordinates, cdof)
 
   use gridData
   implicit none
-  
+
   ! Input Arguments
   integer(kind=intType) ,  intent(in) :: cdof
-  
+
   ! Output Arguments
   real(kind=realType)   ,  intent(inout) :: coordinates(cdof)
-  
+
   ! Local Arguments
   integer(kind=intType) :: ierr, istart, iend, i
-  
+
 
   call VecGetOwnershipRange(Xs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, cdof
-     call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)
+     call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
      call EChk(ierr, __FILE__, __LINE__)
   end do
 

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -2,21 +2,21 @@ subroutine getdXs(output, ndof)
 
   use gridData
   implicit none
-  
+
   ! Input Arguments
   integer(kind=intType) ,  intent(in) :: ndof
-  
+
   ! Output Arguments
   real(kind=realType)   ,  intent(inout) :: output(ndof)
-  
+
   ! Local Arguments
   integer(kind=intType) :: ierr, istart, iend, i
-  
+
   call VecGetOwnershipRange(dXs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, ndof
-     call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)
+     call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
      call EChk(ierr, __FILE__, __LINE__)
   end do
 

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -1,5 +1,6 @@
 subroutine getdXs(output, ndof)
 
+#include <petscversion.h>
   use gridData
   implicit none
 
@@ -16,8 +17,12 @@ subroutine getdXs(output, ndof)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, ndof
-     call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
-     call EChk(ierr, __FILE__, __LINE__)
+#if PETSC_VERSION_MINOR > 13
+      call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
+#else
+      call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)
+#endif
+    call EChk(ierr, __FILE__, __LINE__)
   end do
 
 end subroutine getdXs

--- a/src/warp/verifyWarpDeriv.F90
+++ b/src/warp/verifyWarpDeriv.F90
@@ -1,5 +1,6 @@
 subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
 
+#include <petscversion.h>
   use gridData
   use gridInput
   use communication
@@ -51,7 +52,11 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
 
      ! add h to dof
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(Xs, 1, dof, orig_value, ierr)
+#if PETSC_VERSION_MINOR > 13
+         call VecGetValues(Xs, 1, dof, orig_value, ierr)
+#else
+         call VecGetValues(Xs, 1, (/dof/), orig_value, ierr)
+#endif
         call EChk(ierr, __FILE__, __LINE__)
 
         val = orig_value(1) + h
@@ -123,7 +128,11 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
      call EChk(ierr, __FILE__, __LINE__)
 
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(dXs, 1, dof, ADvalue, ierr)
+#if PETSC_VERSION_MINOR > 13
+         call VecGetValues(dXs, 1, dof, ADvalue, ierr)
+#else
+         call VecGetValues(dXs, 1, (/dof/), ADvalue, ierr)
+#endif
         call EChk(ierr, __FILE__, __LINE__)
         if (abs(half*(FDValue + ADValue(1))) < 1e-16) then
            err = 1e-16

--- a/src/warp/verifyWarpDeriv.F90
+++ b/src/warp/verifyWarpDeriv.F90
@@ -38,7 +38,7 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   if (myid == 0) then
      print *, 'Running AD Version'
   end if
-  
+
   call warpMesh()
   call WarpDeriv(dXv_f, ndof_warp)
 
@@ -47,11 +47,11 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   call EChk(ierr, __FILE__, __LINE__)
 
   ! Loop over desired DOFs
-  do dof=dof_start, dof_end 
-   
+  do dof=dof_start, dof_end
+
      ! add h to dof
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(Xs, 1, (/dof/), orig_value, ierr)
+        call VecGetValues(Xs, 1, dof, orig_value, ierr)
         call EChk(ierr, __FILE__, __LINE__)
 
         val = orig_value(1) + h
@@ -123,14 +123,14 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
      call EChk(ierr, __FILE__, __LINE__)
 
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(dXs, 1, (/dof/), ADvalue, ierr)
+        call VecGetValues(dXs, 1, dof, ADvalue, ierr)
         call EChk(ierr, __FILE__, __LINE__)
         if (abs(half*(FDValue + ADValue(1))) < 1e-16) then
            err = 1e-16
         else
            err = (FDValue-ADValue(1))/(half*(FDValue+ADValue(1)))*100_realType
         end if
-        
+
         write(*, 900) 'DOF:', dof, ' OrigVal: ',orig_value(1), ' AD:', ADValue, ' FD:', &
              FDValue, ' Err(%):', err
      end if
@@ -142,4 +142,4 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   call warpMesh()
 
   deallocate(deriv, xplus, xminus)
-end subroutine verifyWarpDeriv  
+end subroutine verifyWarpDeriv


### PR DESCRIPTION
## Purpose
Fixing issues with the `VecGetValues` function so that idwarp works with newer versions of petsc.

We haven't figured out why, but in newer versions of petsc, `VecGetValues` expects a scalar rather than a single entry array for the index when retrieving a single value. I added some conditional compilation so that we use the correct inputs depending on the petsc version installed and therefore maintain backwards compatibility.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
All testflo tests pass locally

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
