### PR TITLE
Support latest PETSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ src/f2py/libidwarp.pyf.autogen
 src/f2py/libidwarp-f2pywrappers2.f90
 src_cs/f2py/libidwarp_cs-f2pywrappers2.f90
 src_cs/f2py/get_f2py.py
+idwarp.egg-info
+input_files/*/
+input_files/*.tar.gz
+testflo_report.out

--- a/src/warp/getSurfaceCoordinates.F90
+++ b/src/warp/getSurfaceCoordinates.F90
@@ -18,7 +18,7 @@ subroutine getSurfaceCoordinates(coordinates, cdof)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, cdof
-#if PETSC_VERSION_MINOR > 13
+#if PETSC_VERSION_GE(3,14,0)
       call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
 #else
       call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)

--- a/src/warp/getSurfaceCoordinates.F90
+++ b/src/warp/getSurfaceCoordinates.F90
@@ -1,24 +1,29 @@
 subroutine getSurfaceCoordinates(coordinates, cdof)
 
+#include <petscversion.h>
   use gridData
   implicit none
-  
+
   ! Input Arguments
   integer(kind=intType) ,  intent(in) :: cdof
-  
+
   ! Output Arguments
   real(kind=realType)   ,  intent(inout) :: coordinates(cdof)
-  
+
   ! Local Arguments
   integer(kind=intType) :: ierr, istart, iend, i
-  
+
 
   call VecGetOwnershipRange(Xs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, cdof
-     call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)
-     call EChk(ierr, __FILE__, __LINE__)
+#if PETSC_VERSION_MINOR > 13
+      call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
+#else
+      call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)
+#endif
+    call EChk(ierr, __FILE__, __LINE__)
   end do
 
 end subroutine getSurfaceCoordinates

--- a/src/warp/getSurfaceCoordinates.F90
+++ b/src/warp/getSurfaceCoordinates.F90
@@ -1,6 +1,5 @@
 subroutine getSurfaceCoordinates(coordinates, cdof)
 
-#include <petscversion.h>
   use gridData
   implicit none
 
@@ -17,13 +16,7 @@ subroutine getSurfaceCoordinates(coordinates, cdof)
   call VecGetOwnershipRange(Xs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
-  do i=1, cdof
-#if PETSC_VERSION_GE(3,14,0)
-      call VecGetValues(Xs, 1, iStart+i-1, coordinates(i), ierr)
-#else
-      call VecGetValues(Xs, 1, (/iStart+i-1/), coordinates(i), ierr)
-#endif
-    call EChk(ierr, __FILE__, __LINE__)
-  end do
+  call VecGetValues(Xs, cdof, (/(i, i=istart,iend,1)/), coordinates(1:cdof), ierr)
+  call EChk(ierr, __FILE__, __LINE__)
 
 end subroutine getSurfaceCoordinates

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -1,23 +1,28 @@
 subroutine getdXs(output, ndof)
 
+#include <petscversion.h>
   use gridData
   implicit none
-  
+
   ! Input Arguments
   integer(kind=intType) ,  intent(in) :: ndof
-  
+
   ! Output Arguments
   real(kind=realType)   ,  intent(inout) :: output(ndof)
-  
+
   ! Local Arguments
   integer(kind=intType) :: ierr, istart, iend, i
-  
+
   call VecGetOwnershipRange(dXs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, ndof
-     call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)
-     call EChk(ierr, __FILE__, __LINE__)
+#if PETSC_VERSION_MINOR > 13
+      call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
+#else
+      call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)
+#endif
+    call EChk(ierr, __FILE__, __LINE__)
   end do
 
 end subroutine getdXs

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -1,6 +1,5 @@
 subroutine getdXs(output, ndof)
 
-#include <petscversion.h>
   use gridData
   implicit none
 

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -16,13 +16,7 @@ subroutine getdXs(output, ndof)
   call VecGetOwnershipRange(dXs, istart, iend, ierr)
   call EChk(ierr, __FILE__, __LINE__)
 
-  do i=1, ndof
-#if PETSC_VERSION_GE(3,14,0)
-      call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
-#else
-      call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)
-#endif
-    call EChk(ierr, __FILE__, __LINE__)
-  end do
+  call VecGetValues(dXs, ndof, (/(i, i=istart,iend,1)/), output(1:ndof), ierr)
+  call EChk(ierr, __FILE__, __LINE__)
 
 end subroutine getdXs

--- a/src/warp/getdXs.F90
+++ b/src/warp/getdXs.F90
@@ -17,7 +17,7 @@ subroutine getdXs(output, ndof)
   call EChk(ierr, __FILE__, __LINE__)
 
   do i=1, ndof
-#if PETSC_VERSION_MINOR > 13
+#if PETSC_VERSION_GE(3,14,0)
       call VecGetValues(dXs, 1,  i+istart-1, output(i), ierr)
 #else
       call VecGetValues(dXs, 1,  (/i+istart-1/), output(i), ierr)

--- a/src/warp/verifyWarpDeriv.F90
+++ b/src/warp/verifyWarpDeriv.F90
@@ -1,5 +1,6 @@
 subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
 
+#include <petscversion.h>
   use gridData
   use gridInput
   use communication
@@ -38,7 +39,7 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   if (myid == 0) then
      print *, 'Running AD Version'
   end if
-  
+
   call warpMesh()
   call WarpDeriv(dXv_f, ndof_warp)
 
@@ -47,11 +48,15 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   call EChk(ierr, __FILE__, __LINE__)
 
   ! Loop over desired DOFs
-  do dof=dof_start, dof_end 
-   
+  do dof=dof_start, dof_end
+
      ! add h to dof
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(Xs, 1, (/dof/), orig_value, ierr)
+#if PETSC_VERSION_MINOR > 13
+         call VecGetValues(Xs, 1, dof, orig_value, ierr)
+#else
+         call VecGetValues(Xs, 1, (/dof/), orig_value, ierr)
+#endif
         call EChk(ierr, __FILE__, __LINE__)
 
         val = orig_value(1) + h
@@ -123,14 +128,18 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
      call EChk(ierr, __FILE__, __LINE__)
 
      if (dof >= istart .and. dof < iend) then
-        call VecGetValues(dXs, 1, (/dof/), ADvalue, ierr)
+#if PETSC_VERSION_MINOR > 13
+         call VecGetValues(dXs, 1, dof, ADvalue, ierr)
+#else
+         call VecGetValues(dXs, 1, (/dof/), ADvalue, ierr)
+#endif
         call EChk(ierr, __FILE__, __LINE__)
         if (abs(half*(FDValue + ADValue(1))) < 1e-16) then
            err = 1e-16
         else
            err = (FDValue-ADValue(1))/(half*(FDValue+ADValue(1)))*100_realType
         end if
-        
+
         write(*, 900) 'DOF:', dof, ' OrigVal: ',orig_value(1), ' AD:', ADValue, ' FD:', &
              FDValue, ' Err(%):', err
      end if
@@ -142,4 +151,4 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
   call warpMesh()
 
   deallocate(deriv, xplus, xminus)
-end subroutine verifyWarpDeriv  
+end subroutine verifyWarpDeriv

--- a/src/warp/verifyWarpDeriv.F90
+++ b/src/warp/verifyWarpDeriv.F90
@@ -52,7 +52,7 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
 
      ! add h to dof
      if (dof >= istart .and. dof < iend) then
-#if PETSC_VERSION_MINOR > 13
+#if PETSC_VERSION_GE(3,14,0)
          call VecGetValues(Xs, 1, dof, orig_value, ierr)
 #else
          call VecGetValues(Xs, 1, (/dof/), orig_value, ierr)
@@ -128,7 +128,7 @@ subroutine verifyWarpDeriv(dXv_f, ndof_warp, dof_start, dof_end, h)
      call EChk(ierr, __FILE__, __LINE__)
 
      if (dof >= istart .and. dof < iend) then
-#if PETSC_VERSION_MINOR > 13
+#if PETSC_VERSION_GE(3,14,0)
          call VecGetValues(dXs, 1, dof, ADvalue, ierr)
 #else
          call VecGetValues(dXs, 1, (/dof/), ADvalue, ierr)


### PR DESCRIPTION
## Purpose
Fixing issues with the VecGetValues function so that idwarp works with newer versions of petsc, part of tackling https://github.com/mdolab/docker/issues/83.

We haven't figured out why, but in newer versions of petsc, VecGetValues expects a scalar rather than a single entry array for the index when retrieving a single value. I added some conditional compilation so that we use the correct inputs depending on the petsc version installed and therefore maintain backwards compatibility.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Testflo tests pass locally with petsc 3.12 and on docker image with 3.15

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
