### PR TITLE
Fix auto edit for AD code

### DIFF
--- a/src/adjoint/autoEdit/utils.py
+++ b/src/adjoint/autoEdit/utils.py
@@ -26,7 +26,7 @@ def processFiles(EXT, DIR_ORI, DIR_MOD, LINE_ID, STR_OLD, STR_NEW, STR_REPLACE_A
                 print(f"\nParsing input file {file_object_ori.name}")
 
                 # open modified file in write mode
-                file_object_mod = open(os.path.join(DIR_ORI, f), "w")
+                file_object_mod = open(os.path.join(DIR_MOD, f), "w")
 
                 # read the original file, line-by-line
                 nEdits = len(LINE_ID)


### PR DESCRIPTION
## Purpose
This PR fixes a small bug in the autoediting of the differentiated files, resulting in them not getting updated.

## Expected time until merged
When tests pass

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
