### PR TITLE
Bump minimum numpy to 1.25, version to 2.6.4

### DIFF
--- a/idwarp/__init__.py
+++ b/idwarp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 
 from .UnstructuredMesh import USMesh
 from .UnstructuredMesh_C import USMesh_C

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "idwarp",
     ],
     package_data={"idwarp": ["*.so"]},
+    python_requires=">=3.11",
     install_requires=[
         "numpy>=1.25",
         "mpi4py>=3.1.5",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     package_data={"idwarp": ["*.so"]},
     install_requires=[
-        "numpy>=1.21",
+        "numpy>=1.25",
         "mpi4py>=3.1.5",
         "mdolab-baseclasses>=1.4",
     ],


### PR DESCRIPTION
Update numpy minimum supported version from 1.21 to 1.25 to match updated docker image dependencies. Bumps patch version from 2.6.3 to 2.6.4.