### PR TITLE
Fix zero AD derivative of getRotationMatrix3d at an undeformed mesh

### DIFF
--- a/src/adjoint/outputForward/vectorUtils_d.f90
+++ b/src/adjoint/outputForward/vectorUtils_d.f90
@@ -14,118 +14,91 @@
    REAL(kind=realtype), DIMENSION(3, 3), INTENT(OUT) :: mi
    REAL(kind=realtype), DIMENSION(3, 3), INTENT(OUT) :: mib
    ! Local Variables
-   REAL(kind=realtype), DIMENSION(3) :: axis, vv1, vv2
-   REAL(kind=realtype), DIMENSION(3) :: axisb, vv2b
-   REAL(kind=realtype) :: magv1, magv2, axismag, angle, arg
-   REAL(kind=realtype) :: magv2b, axismagb, angleb, argb
-   REAL(kind=realtype), DIMENSION(3, 3) :: a, c
-   REAL(kind=realtype), DIMENSION(3, 3) :: ab, cb
-   REAL(kind=realtype), PARAMETER :: tol=1.4901161193847656e-08
-   INTRINSIC MIN
-   INTRINSIC ACOS
-   INTRINSIC SIN
-   INTRINSIC COS
+   REAL(kind=realtype), DIMENSION(3) :: a
+   REAL(kind=realtype), DIMENSION(3) :: ab
+   REAL(kind=realtype) :: magv1, magv2, s, dot, denom2
+   REAL(kind=realtype) :: magv2b, sb, dotb, denom2b
+   REAL(kind=realtype), DIMENSION(3, 3) :: p, c
+   REAL(kind=realtype), DIMENSION(3, 3) :: pb, cb
+   REAL(kind=realtype), PARAMETER :: dtol=1.0e-10
    REAL(kind=realtype), DIMENSION(3) :: v1b
-   REAL(kind=realtype) :: temp
-   REAL(kind=realtype) :: temp0
+   ! Rotation taking the direction of v1 to the direction of v2, in a
+   ! smooth branch-free form.  With theta the angle between v1 and v2,
+   ! a = v1 x v2 and s = |v1||v2|, the two axis-angle pieces of the
+   ! Rodrigues formula reduce EXACTLY (for 0 <= theta < pi) to
+   !     sin(theta) * Ahat        = skew(a) / s
+   !     (1-cos(theta)) * Ahat^2  = skew(a)^2 / (s^2 + s*(v1.v2))
+   ! so no normalized axis, no acos and no angle are ever formed.  The
+   ! axis-angle version this replaces needed an axisMag < tol branch at
+   ! theta = 0, and BOTH AD derivatives (_b and _d) of that branch were
+   ! identically zero while the true derivative there is finite: every
+   ! surface node of an UNDEFORMED mesh evaluates at exactly theta = 0,
+   ! so warpDeriv/warpDerivFwd silently dropped the entire rotation
+   ! contribution when linearized at the baseline configuration.  This
+   ! form has a removable limit at theta = 0 (a = 0 makes the rotation
+   ! terms vanish smoothly) and differentiates correctly there by
+   ! construction.  Only theta -> pi (anti-parallel normals, a folded
+   ! surface) is guarded, where the rotation genuinely is not unique.
    CALL GETMAG(v1, magv1)
    CALL GETMAG_D(v2, v2b, magv2, magv2b)
-   ! Start by determining the rotation axis by getting the
-   ! cross product between v1, v2
-   axisb = 0.0_8
-   v1b = 0.0_8
-   CALL CROSS_PRODUCT_3D_D(v1, v1b, v2, v2b, axis, axisb)
-   ! Now Normalize
-   CALL GETMAG_D(axis, axisb, axismag, axismagb)
-   ! When axisMag is less that sqrt(eps), the acos 'arg' value will be
-   ! exactly one which will give a nan in complex mode.
-   IF (axismag .LT. tol) THEN
-   ! no rotation at this point, angle is 0
-   angle = zero
-   ! the axis doesn't matter so set to x
-   axis = zero
-   axis(1) = one
-   axisb = 0.0_8
-   angleb = 0.0_8
-   ELSE
-   axisb = (axisb-axis*axismagb/axismag)/axismag
-   axis = axis/axismag
-   ! Now compute the rotation angle about that axis
-   vv1 = v1/magv1
-   vv2b = (v2b-v2*magv2b/magv2)/magv2
-   vv2 = v2/magv2
-   IF (one .GT. vv1(1)*vv2(1) + vv1(2)*vv2(2) + vv1(3)*vv2(3)) THEN
-   argb = vv1(1)*vv2b(1) + vv1(2)*vv2b(2) + vv1(3)*vv2b(3)
-   arg = vv1(1)*vv2(1) + vv1(2)*vv2(2) + vv1(3)*vv2(3)
-   ELSE
-   arg = one
-   argb = 0.0_8
-   END IF
-   IF (arg .EQ. 1.0 .OR. arg .EQ. (-1.0)) THEN
-   angleb = 0.0_8
-   ELSE
-   angleb = -(argb/SQRT(1.0-arg**2))
-   END IF
-   angle = ACOS(arg)
-   END IF
-   ! Now that we have an axis and an angle,build the rotation Matrix
-   ! A skew symmetric representation of the normalized axis
-   a(1, 1) = zero
    ab = 0.0_8
-   ab(1, 2) = -axisb(3)
-   a(1, 2) = -axis(3)
-   ab(1, 3) = axisb(2)
-   a(1, 3) = axis(2)
-   ab(2, 1) = axisb(3)
-   a(2, 1) = axis(3)
-   ab(2, 2) = 0.0_8
-   a(2, 2) = zero
-   ab(2, 3) = -axisb(1)
-   a(2, 3) = -axis(1)
-   ab(3, 1) = -axisb(2)
-   a(3, 1) = -axis(2)
-   ab(3, 2) = axisb(1)
-   a(3, 2) = axis(1)
-   ab(3, 3) = 0.0_8
-   a(3, 3) = zero
-   !C = A*A
+   v1b = 0.0_8
+   CALL CROSS_PRODUCT_3D_D(v1, v1b, v2, v2b, a, ab)
+   sb = magv1*magv2b
+   s = magv1*magv2
+   dotb = v1(1)*v2b(1) + v1(2)*v2b(2) + v1(3)*v2b(3)
+   dot = v1(1)*v2(1) + v1(2)*v2(2) + v1(3)*v2(3)
+   denom2b = (2*s+dot)*sb + s*dotb
+   denom2 = s*s + s*dot
+   IF (denom2 .LT. dtol*s*s) THEN
+   denom2b = dtol*2*s*sb
+   denom2 = dtol*s*s
+   END IF
+   ! P = skew(a)
+   p(1, 1) = zero
+   pb = 0.0_8
+   pb(1, 2) = -ab(3)
+   p(1, 2) = -a(3)
+   pb(1, 3) = ab(2)
+   p(1, 3) = a(2)
+   pb(2, 1) = ab(3)
+   p(2, 1) = a(3)
+   pb(2, 2) = 0.0_8
+   p(2, 2) = zero
+   pb(2, 3) = -ab(1)
+   p(2, 3) = -a(1)
+   pb(3, 1) = -ab(2)
+   p(3, 1) = -a(2)
+   pb(3, 2) = ab(1)
+   p(3, 2) = a(1)
+   pb(3, 3) = 0.0_8
+   p(3, 3) = zero
+   ! C = P*P = a a^T - (a.a) I
    cb = 0.0_8
-   cb(1, 1) = 2*a(1, 1)*ab(1, 1) + a(2, 1)*ab(1, 2) + a(1, 2)*ab(2, 1) + &
-   &   a(3, 1)*ab(1, 3) + a(1, 3)*ab(3, 1)
-   c(1, 1) = a(1, 1)*a(1, 1) + a(1, 2)*a(2, 1) + a(1, 3)*a(3, 1)
-   cb(1, 2) = a(1, 2)*ab(1, 1) + (a(1, 1)+a(2, 2))*ab(1, 2) + a(1, 2)*ab(&
-   &   2, 2) + a(3, 2)*ab(1, 3) + a(1, 3)*ab(3, 2)
-   c(1, 2) = a(1, 1)*a(1, 2) + a(1, 2)*a(2, 2) + a(1, 3)*a(3, 2)
-   cb(1, 3) = a(1, 3)*ab(1, 1) + (a(1, 1)+a(3, 3))*ab(1, 3) + a(2, 3)*ab(&
-   &   1, 2) + a(1, 2)*ab(2, 3) + a(1, 3)*ab(3, 3)
-   c(1, 3) = a(1, 1)*a(1, 3) + a(1, 2)*a(2, 3) + a(1, 3)*a(3, 3)
-   cb(2, 1) = (a(1, 1)+a(2, 2))*ab(2, 1) + a(2, 1)*ab(1, 1) + a(2, 1)*ab(&
-   &   2, 2) + a(3, 1)*ab(2, 3) + a(2, 3)*ab(3, 1)
-   c(2, 1) = a(2, 1)*a(1, 1) + a(2, 2)*a(2, 1) + a(2, 3)*a(3, 1)
-   cb(2, 2) = a(1, 2)*ab(2, 1) + a(2, 1)*ab(1, 2) + 2*a(2, 2)*ab(2, 2) + &
-   &   a(3, 2)*ab(2, 3) + a(2, 3)*ab(3, 2)
-   c(2, 2) = a(2, 1)*a(1, 2) + a(2, 2)*a(2, 2) + a(2, 3)*a(3, 2)
-   cb(2, 3) = a(1, 3)*ab(2, 1) + a(2, 1)*ab(1, 3) + a(2, 3)*ab(2, 2) + (a&
-   &   (2, 2)+a(3, 3))*ab(2, 3) + a(2, 3)*ab(3, 3)
-   c(2, 3) = a(2, 1)*a(1, 3) + a(2, 2)*a(2, 3) + a(2, 3)*a(3, 3)
-   cb(3, 1) = (a(1, 1)+a(3, 3))*ab(3, 1) + a(3, 1)*ab(1, 1) + a(2, 1)*ab(&
-   &   3, 2) + a(3, 2)*ab(2, 1) + a(3, 1)*ab(3, 3)
-   c(3, 1) = a(3, 1)*a(1, 1) + a(3, 2)*a(2, 1) + a(3, 3)*a(3, 1)
-   cb(3, 2) = a(1, 2)*ab(3, 1) + a(3, 1)*ab(1, 2) + (a(2, 2)+a(3, 3))*ab(&
-   &   3, 2) + a(3, 2)*ab(2, 2) + a(3, 2)*ab(3, 3)
-   c(3, 2) = a(3, 1)*a(1, 2) + a(3, 2)*a(2, 2) + a(3, 3)*a(3, 2)
-   cb(3, 3) = a(1, 3)*ab(3, 1) + a(3, 1)*ab(1, 3) + a(2, 3)*ab(3, 2) + a(&
-   &   3, 2)*ab(2, 3) + 2*a(3, 3)*ab(3, 3)
-   c(3, 3) = a(3, 1)*a(1, 3) + a(3, 2)*a(2, 3) + a(3, 3)*a(3, 3)
-   ! Rodrigues formula for the rotation matrix
+   cb(1, 1) = -(2*a(2)*ab(2)) - 2*a(3)*ab(3)
+   c(1, 1) = -(a(2)*a(2)) - a(3)*a(3)
+   cb(1, 2) = a(2)*ab(1) + a(1)*ab(2)
+   c(1, 2) = a(1)*a(2)
+   cb(1, 3) = a(3)*ab(1) + a(1)*ab(3)
+   c(1, 3) = a(1)*a(3)
+   cb(2, 1) = a(2)*ab(1) + a(1)*ab(2)
+   c(2, 1) = a(1)*a(2)
+   cb(2, 2) = -(2*a(1)*ab(1)) - 2*a(3)*ab(3)
+   c(2, 2) = -(a(1)*a(1)) - a(3)*a(3)
+   cb(2, 3) = a(3)*ab(2) + a(2)*ab(3)
+   c(2, 3) = a(2)*a(3)
+   cb(3, 1) = a(3)*ab(1) + a(1)*ab(3)
+   c(3, 1) = a(1)*a(3)
+   cb(3, 2) = a(3)*ab(2) + a(2)*ab(3)
+   c(3, 2) = a(2)*a(3)
+   cb(3, 3) = -(2*a(1)*ab(1)) - 2*a(2)*ab(2)
+   c(3, 3) = -(a(1)*a(1)) - a(2)*a(2)
    mi = zero
    mi(1, 1) = one
    mi(2, 2) = one
    mi(3, 3) = one
-   temp = SIN(angle)
-   temp0 = one - COS(angle)
-   mib = (a*COS(angle)+c*SIN(angle))*angleb + temp*ab + temp0*cb
-   mi = mi + temp*a + temp0*c
+   mib = (pb-p*sb/s)/s + (cb-c*denom2b/denom2)/denom2
+   mi = mi + p/s + c/denom2
    END SUBROUTINE GETROTATIONMATRIX3D_D
       !  Differentiation of cross_product_3d in forward (tangent) mode (with options noISIZE i4 dr8 r8):
    !   variations   of useful results: cross

--- a/src/adjoint/outputReverse/vectorUtils_b.f90
+++ b/src/adjoint/outputReverse/vectorUtils_b.f90
@@ -14,142 +14,105 @@
    REAL(kind=realtype), DIMENSION(3, 3) :: mi
    REAL(kind=realtype), DIMENSION(3, 3) :: mib
    ! Local Variables
-   REAL(kind=realtype), DIMENSION(3) :: axis, vv1, vv2
-   REAL(kind=realtype), DIMENSION(3) :: axisb, vv2b
-   REAL(kind=realtype) :: magv1, magv2, axismag, angle, arg
-   REAL(kind=realtype) :: magv2b, axismagb, angleb, argb
-   REAL(kind=realtype), DIMENSION(3, 3) :: a, c
-   REAL(kind=realtype), DIMENSION(3, 3) :: ab, cb
-   REAL(kind=realtype), PARAMETER :: tol=1.4901161193847656e-08
-   INTRINSIC MIN
-   INTRINSIC ACOS
-   INTRINSIC SIN
-   INTRINSIC COS
+   REAL(kind=realtype), DIMENSION(3) :: a
+   REAL(kind=realtype), DIMENSION(3) :: ab
+   REAL(kind=realtype) :: magv1, magv2, s, dot, denom2
+   REAL(kind=realtype) :: magv2b, sb, dotb, denom2b
+   REAL(kind=realtype), DIMENSION(3, 3) :: p, c
+   REAL(kind=realtype), DIMENSION(3, 3) :: pb, cb
+   REAL(kind=realtype), PARAMETER :: dtol=1.0e-10
    REAL(kind=realtype), DIMENSION(3) :: v1b
    INTEGER :: branch
+   ! Rotation taking the direction of v1 to the direction of v2, in a
+   ! smooth branch-free form.  With theta the angle between v1 and v2,
+   ! a = v1 x v2 and s = |v1||v2|, the two axis-angle pieces of the
+   ! Rodrigues formula reduce EXACTLY (for 0 <= theta < pi) to
+   !     sin(theta) * Ahat        = skew(a) / s
+   !     (1-cos(theta)) * Ahat^2  = skew(a)^2 / (s^2 + s*(v1.v2))
+   ! so no normalized axis, no acos and no angle are ever formed.  The
+   ! axis-angle version this replaces needed an axisMag < tol branch at
+   ! theta = 0, and BOTH AD derivatives (_b and _d) of that branch were
+   ! identically zero while the true derivative there is finite: every
+   ! surface node of an UNDEFORMED mesh evaluates at exactly theta = 0,
+   ! so warpDeriv/warpDerivFwd silently dropped the entire rotation
+   ! contribution when linearized at the baseline configuration.  This
+   ! form has a removable limit at theta = 0 (a = 0 makes the rotation
+   ! terms vanish smoothly) and differentiates correctly there by
+   ! construction.  Only theta -> pi (anti-parallel normals, a folded
+   ! surface) is guarded, where the rotation genuinely is not unique.
    CALL GETMAG(v1, magv1)
    CALL GETMAG(v2, magv2)
-   ! Start by determining the rotation axis by getting the
-   ! cross product between v1, v2
-   CALL CROSS_PRODUCT_3D(v1, v2, axis)
-   ! Now Normalize
-   CALL GETMAG(axis, axismag)
-   ! When axisMag is less that sqrt(eps), the acos 'arg' value will be
-   ! exactly one which will give a nan in complex mode.
-   IF (axismag .LT. tol) THEN
-   ! no rotation at this point, angle is 0
-   angle = zero
-   ! the axis doesn't matter so set to x
-   CALL PUSHREAL8ARRAY(axis, realtype*3/8)
-   axis = zero
-   axis(1) = one
+   CALL CROSS_PRODUCT_3D(v1, v2, a)
+   s = magv1*magv2
+   dot = v1(1)*v2(1) + v1(2)*v2(2) + v1(3)*v2(3)
+   denom2 = s*s + s*dot
+   IF (denom2 .LT. dtol*s*s) THEN
+   denom2 = dtol*s*s
    CALL PUSHCONTROL1B(0)
    ELSE
-   CALL PUSHREAL8ARRAY(axis, realtype*3/8)
-   axis = axis/axismag
-   ! Now compute the rotation angle about that axis
-   vv1 = v1/magv1
-   vv2 = v2/magv2
-   IF (one .GT. vv1(1)*vv2(1) + vv1(2)*vv2(2) + vv1(3)*vv2(3)) THEN
-   arg = vv1(1)*vv2(1) + vv1(2)*vv2(2) + vv1(3)*vv2(3)
-   CALL PUSHCONTROL1B(0)
-   ELSE
-   arg = one
    CALL PUSHCONTROL1B(1)
    END IF
-   angle = ACOS(arg)
-   CALL PUSHCONTROL1B(1)
-   END IF
-   ! Now that we have an axis and an angle,build the rotation Matrix
-   ! A skew symmetric representation of the normalized axis
-   a(1, 1) = zero
-   a(1, 2) = -axis(3)
-   a(1, 3) = axis(2)
-   a(2, 1) = axis(3)
-   a(2, 2) = zero
-   a(2, 3) = -axis(1)
-   a(3, 1) = -axis(2)
-   a(3, 2) = axis(1)
-   a(3, 3) = zero
-   !C = A*A
-   c(1, 1) = a(1, 1)*a(1, 1) + a(1, 2)*a(2, 1) + a(1, 3)*a(3, 1)
-   c(1, 2) = a(1, 1)*a(1, 2) + a(1, 2)*a(2, 2) + a(1, 3)*a(3, 2)
-   c(1, 3) = a(1, 1)*a(1, 3) + a(1, 2)*a(2, 3) + a(1, 3)*a(3, 3)
-   c(2, 1) = a(2, 1)*a(1, 1) + a(2, 2)*a(2, 1) + a(2, 3)*a(3, 1)
-   c(2, 2) = a(2, 1)*a(1, 2) + a(2, 2)*a(2, 2) + a(2, 3)*a(3, 2)
-   c(2, 3) = a(2, 1)*a(1, 3) + a(2, 2)*a(2, 3) + a(2, 3)*a(3, 3)
-   c(3, 1) = a(3, 1)*a(1, 1) + a(3, 2)*a(2, 1) + a(3, 3)*a(3, 1)
-   c(3, 2) = a(3, 1)*a(1, 2) + a(3, 2)*a(2, 2) + a(3, 3)*a(3, 2)
-   c(3, 3) = a(3, 1)*a(1, 3) + a(3, 2)*a(2, 3) + a(3, 3)*a(3, 3)
-   ! Rodrigues formula for the rotation matrix
-   ab = 0.0_8
+   ! P = skew(a)
+   p(1, 1) = zero
+   p(1, 2) = -a(3)
+   p(1, 3) = a(2)
+   p(2, 1) = a(3)
+   p(2, 2) = zero
+   p(2, 3) = -a(1)
+   p(3, 1) = -a(2)
+   p(3, 2) = a(1)
+   p(3, 3) = zero
+   ! C = P*P = a a^T - (a.a) I
+   c(1, 1) = -(a(2)*a(2)) - a(3)*a(3)
+   c(1, 2) = a(1)*a(2)
+   c(1, 3) = a(1)*a(3)
+   c(2, 1) = a(1)*a(2)
+   c(2, 2) = -(a(1)*a(1)) - a(3)*a(3)
+   c(2, 3) = a(2)*a(3)
+   c(3, 1) = a(1)*a(3)
+   c(3, 2) = a(2)*a(3)
+   c(3, 3) = -(a(1)*a(1)) - a(2)*a(2)
+   pb = 0.0_8
    cb = 0.0_8
-   angleb = COS(angle)*SUM(a*mib) + SIN(angle)*SUM(c*mib)
-   ab = SIN(angle)*mib
-   cb = (one-COS(angle))*mib
-   ab(3, 1) = ab(3, 1) + a(1, 3)*cb(3, 3) + a(1, 2)*cb(3, 2) + (a(1, 1)+a&
-   &   (3, 3))*cb(3, 1) + a(2, 3)*cb(2, 1) + a(1, 3)*cb(1, 1)
-   ab(1, 3) = ab(1, 3) + a(3, 1)*cb(3, 3) + a(2, 1)*cb(2, 3) + (a(1, 1)+a&
-   &   (3, 3))*cb(1, 3) + a(3, 2)*cb(1, 2) + a(3, 1)*cb(1, 1)
-   ab(3, 2) = ab(3, 2) + a(2, 3)*cb(3, 3) + (a(2, 2)+a(3, 3))*cb(3, 2) + &
-   &   a(2, 1)*cb(3, 1) + a(2, 3)*cb(2, 2) + a(1, 3)*cb(1, 2)
-   ab(2, 3) = ab(2, 3) + a(3, 2)*cb(3, 3) + (a(2, 2)+a(3, 3))*cb(2, 3) + &
-   &   a(3, 2)*cb(2, 2) + a(3, 1)*cb(2, 1) + a(1, 2)*cb(1, 3)
-   ab(1, 2) = ab(1, 2) + a(3, 1)*cb(3, 2) + a(2, 1)*cb(2, 2) + a(2, 3)*cb&
-   &   (1, 3) + (a(1, 1)+a(2, 2))*cb(1, 2) + a(2, 1)*cb(1, 1)
-   ab(1, 1) = ab(1, 1) + a(3, 1)*cb(3, 1) + a(2, 1)*cb(2, 1) + a(1, 3)*cb&
-   &   (1, 3) + a(1, 2)*cb(1, 2) + 2*a(1, 1)*cb(1, 1)
-   ab(2, 1) = ab(2, 1) + a(3, 2)*cb(3, 1) + a(1, 3)*cb(2, 3) + a(1, 2)*cb&
-   &   (2, 2) + (a(1, 1)+a(2, 2))*cb(2, 1) + a(1, 2)*cb(1, 1)
-   ab(3, 3) = 0.0_8
+   pb = mib/s
+   sb = -(SUM(p*mib)/s**2)
+   cb = mib/denom2
+   denom2b = -(SUM(c*mib)/denom2**2)
+   ab = 0.0_8
+   ab(1) = ab(1) + a(3)*cb(3, 1) - 2*a(1)*cb(3, 3) + a(2)*cb(2, 1) - 2*a(&
+   &   1)*cb(2, 2) + a(3)*cb(1, 3) + a(2)*cb(1, 2) + pb(3, 2) - pb(2, 3)
+   ab(2) = ab(2) + a(3)*cb(3, 2) - 2*a(2)*cb(3, 3) + a(3)*cb(2, 3) + a(1)&
+   &   *cb(2, 1) + a(1)*cb(1, 2) + pb(1, 3) - 2*a(2)*cb(1, 1) - pb(3, 1)
    cb(3, 3) = 0.0_8
-   cb(3, 1) = 0.0_8
-   cb(1, 3) = 0.0_8
-   axisb = 0.0_8
-   axisb(1) = axisb(1) + ab(3, 2) - ab(2, 3)
-   ab(3, 2) = 0.0_8
-   axisb(2) = axisb(2) + ab(1, 3) - ab(3, 1)
-   ab(3, 1) = 0.0_8
-   ab(2, 3) = 0.0_8
-   ab(2, 2) = 0.0_8
+   ab(3) = ab(3) + a(2)*cb(3, 2) + a(1)*cb(3, 1) + a(2)*cb(2, 3) + a(1)*&
+   &   cb(1, 3) - 2*a(3)*cb(2, 2) + pb(2, 1) - 2*a(3)*cb(1, 1) - pb(1, 2)
    cb(3, 2) = 0.0_8
+   cb(3, 1) = 0.0_8
    cb(2, 3) = 0.0_8
    cb(2, 2) = 0.0_8
    cb(2, 1) = 0.0_8
+   cb(1, 3) = 0.0_8
    cb(1, 2) = 0.0_8
-   axisb(3) = axisb(3) + ab(2, 1) - ab(1, 2)
-   ab(2, 1) = 0.0_8
-   ab(1, 3) = 0.0_8
+   pb(3, 3) = 0.0_8
+   pb(3, 2) = 0.0_8
+   pb(3, 1) = 0.0_8
+   pb(2, 3) = 0.0_8
+   pb(2, 2) = 0.0_8
+   pb(2, 1) = 0.0_8
+   pb(1, 3) = 0.0_8
    CALL POPCONTROL1B(branch)
    IF (branch .EQ. 0) THEN
-   CALL POPREAL8ARRAY(axis, realtype*3/8)
-   magv2b = 0.0_8
-   axisb = 0.0_8
-   axismagb = 0.0_8
-   ELSE
-   IF (arg .EQ. 1.0 .OR. arg .EQ. (-1.0)) THEN
-   argb = 0.0_8
-   ELSE
-   argb = -(angleb/SQRT(1.0-arg**2))
+   sb = sb + 2*s*dtol*denom2b
+   denom2b = 0.0_8
    END IF
-   CALL POPCONTROL1B(branch)
-   IF (branch .EQ. 0) THEN
-   vv2b = 0.0_8
-   vv2b(1) = vv2b(1) + vv1(1)*argb
-   vv2b(2) = vv2b(2) + vv1(2)*argb
-   vv2b(3) = vv2b(3) + vv1(3)*argb
-   ELSE
-   vv2b = 0.0_8
-   END IF
-   v2b = v2b + vv2b/magv2
-   magv2b = -(SUM(v2*vv2b)/magv2**2)
-   CALL POPREAL8ARRAY(axis, realtype*3/8)
-   axismagb = -(SUM(axis*axisb)/axismag**2)
-   axisb = axisb/axismag
-   END IF
-   CALL GETMAG_B(axis, axisb, axismag, axismagb)
+   sb = sb + (2*s+dot)*denom2b
+   dotb = s*denom2b
+   v2b(1) = v2b(1) + v1(1)*dotb
+   v2b(2) = v2b(2) + v1(2)*dotb
+   v2b(3) = v2b(3) + v1(3)*dotb
+   magv2b = magv1*sb
    v1b = 0.0_8
-   CALL CROSS_PRODUCT_3D_B(v1, v1b, v2, v2b, axis, axisb)
+   CALL CROSS_PRODUCT_3D_B(v1, v1b, v2, v2b, a, ab)
    CALL GETMAG_B(v2, v2b, magv2, magv2b)
    END SUBROUTINE GETROTATIONMATRIX3D_B
       !  Differentiation of cross_product_3d in reverse (adjoint) mode (with options noISIZE i4 dr8 r8):

--- a/src/utils/vectorUtils.f90
+++ b/src/utils/vectorUtils.f90
@@ -38,66 +38,66 @@ subroutine getRotationMatrix3d(v1, v2, Mi)
     real(kind=realType), dimension(3, 3), intent(out) :: Mi
 
     ! Local Variables
-    real(kind=realType), dimension(3) :: axis, vv1, vv2
-    real(kind=realType) :: magV1, magV2, axisMag, angle, arg
-    real(kind=realType), dimension(3, 3) :: A, C
-    real(kind=realType), parameter :: tol = 1.4901161193847656e-08
+    real(kind=realType), dimension(3) :: a
+    real(kind=realType) :: magV1, magV2, s, dot, denom2
+    real(kind=realType), dimension(3, 3) :: P, C
+    real(kind=realType), parameter :: dtol = 1.0e-10
+
+    ! Rotation taking the direction of v1 to the direction of v2, in a
+    ! smooth branch-free form.  With theta the angle between v1 and v2,
+    ! a = v1 x v2 and s = |v1||v2|, the two axis-angle pieces of the
+    ! Rodrigues formula reduce EXACTLY (for 0 <= theta < pi) to
+    !     sin(theta) * Ahat        = skew(a) / s
+    !     (1-cos(theta)) * Ahat^2  = skew(a)^2 / (s^2 + s*(v1.v2))
+    ! so no normalized axis, no acos and no angle are ever formed.  The
+    ! axis-angle version this replaces needed an axisMag < tol branch at
+    ! theta = 0, and BOTH AD derivatives (_b and _d) of that branch were
+    ! identically zero while the true derivative there is finite: every
+    ! surface node of an UNDEFORMED mesh evaluates at exactly theta = 0,
+    ! so warpDeriv/warpDerivFwd silently dropped the entire rotation
+    ! contribution when linearized at the baseline configuration.  This
+    ! form has a removable limit at theta = 0 (a = 0 makes the rotation
+    ! terms vanish smoothly) and differentiates correctly there by
+    ! construction.  Only theta -> pi (anti-parallel normals, a folded
+    ! surface) is guarded, where the rotation genuinely is not unique.
 
     call getMag(v1, magV1)
     call getMag(v2, magV2)
-
-    ! Start by determining the rotation axis by getting the
-    ! cross product between v1, v2
-
-    call cross_product_3d(v1, v2, axis)
-    ! Now Normalize
-    call getMag(axis, axisMag)
-
-    ! When axisMag is less that sqrt(eps), the acos 'arg' value will be
-    ! exactly one which will give a nan in complex mode.
-    if (axisMag < tol) then
-        ! no rotation at this point, angle is 0
-        angle = zero
-        ! the axis doesn't matter so set to x
-        axis = zero
-        axis(1) = one
-    else
-        axis = axis / axisMag
-        ! Now compute the rotation angle about that axis
-        vv1 = v1 / magv1
-        vv2 = v2 / magv2
-        arg = min(one, vv1(1) * vv2(1) + vv1(2) * vv2(2) + vv1(3) * vv2(3))
-        angle = acos(arg)
+    call cross_product_3d(v1, v2, a)
+    s = magV1 * magV2
+    dot = v1(1) * v2(1) + v1(2) * v2(2) + v1(3) * v2(3)
+    denom2 = s * s + s * dot
+    if (denom2 < dtol * s * s) then
+        denom2 = dtol * s * s
     end if
-    ! Now that we have an axis and an angle,build the rotation Matrix
-    ! A skew symmetric representation of the normalized axis
-    A(1, 1) = zero
-    A(1, 2) = -axis(3)
-    A(1, 3) = axis(2)
-    A(2, 1) = axis(3)
-    A(2, 2) = zero
-    A(2, 3) = -axis(1)
-    A(3, 1) = -axis(2)
-    A(3, 2) = axis(1)
-    A(3, 3) = zero
 
-    !C = A*A
-    C(1, 1) = A(1, 1) * A(1, 1) + A(1, 2) * A(2, 1) + A(1, 3) * A(3, 1)
-    C(1, 2) = A(1, 1) * A(1, 2) + A(1, 2) * A(2, 2) + A(1, 3) * A(3, 2)
-    C(1, 3) = A(1, 1) * A(1, 3) + A(1, 2) * A(2, 3) + A(1, 3) * A(3, 3)
-    C(2, 1) = A(2, 1) * A(1, 1) + A(2, 2) * A(2, 1) + A(2, 3) * A(3, 1)
-    C(2, 2) = A(2, 1) * A(1, 2) + A(2, 2) * A(2, 2) + A(2, 3) * A(3, 2)
-    C(2, 3) = A(2, 1) * A(1, 3) + A(2, 2) * A(2, 3) + A(2, 3) * A(3, 3)
-    C(3, 1) = A(3, 1) * A(1, 1) + A(3, 2) * A(2, 1) + A(3, 3) * A(3, 1)
-    C(3, 2) = A(3, 1) * A(1, 2) + A(3, 2) * A(2, 2) + A(3, 3) * A(3, 2)
-    C(3, 3) = A(3, 1) * A(1, 3) + A(3, 2) * A(2, 3) + A(3, 3) * A(3, 3)
+    ! P = skew(a)
+    P(1, 1) = zero
+    P(1, 2) = -a(3)
+    P(1, 3) = a(2)
+    P(2, 1) = a(3)
+    P(2, 2) = zero
+    P(2, 3) = -a(1)
+    P(3, 1) = -a(2)
+    P(3, 2) = a(1)
+    P(3, 3) = zero
 
-    ! Rodrigues formula for the rotation matrix
+    ! C = P*P = a a^T - (a.a) I
+    C(1, 1) = -a(2) * a(2) - a(3) * a(3)
+    C(1, 2) = a(1) * a(2)
+    C(1, 3) = a(1) * a(3)
+    C(2, 1) = a(1) * a(2)
+    C(2, 2) = -a(1) * a(1) - a(3) * a(3)
+    C(2, 3) = a(2) * a(3)
+    C(3, 1) = a(1) * a(3)
+    C(3, 2) = a(2) * a(3)
+    C(3, 3) = -a(1) * a(1) - a(2) * a(2)
+
     Mi = zero
     Mi(1, 1) = one
     Mi(2, 2) = one
     Mi(3, 3) = one
 
-    Mi = Mi + sin(angle) * A + (one - cos(angle)) * C
+    Mi = Mi + P / s + C / denom2
 
 end subroutine getRotationMatrix3d


### PR DESCRIPTION
## Purpose

`getRotationMatrix3d` (`src/utils/vectorUtils.f90`) builds the per-surface-node rotation `Mi` (initial normal `v1` -> current normal `v2`) with an axis-angle Rodrigues form guarded by

```fortran
if (axisMag < tol) then          ! tol = sqrt(eps) = 1.4901161193847656e-08
    angle = zero
    axis = zero; axis(1) = one
else
    ...
end if
```

At an **undeformed mesh the current normal equals the initial normal at every surface node**, so `axis = v1 x v2 = 0` and the primal takes the guarded branch everywhere. The Tapenade derivatives of that branch are identically zero:

* `GETROTATIONMATRIX3D_D` sets `axisb = 0` and `angleb = 0`; `ab` is built entirely from `axisb` and `cb` entirely from `ab`, so `mib` is exactly zero.
* `GETROTATIONMATRIX3D_B` correctly accumulates `axisb` from the incoming `mib` and then discards it (`magv2b = 0; axisb = 0; axismagb = 0`), returning `v2b` bit-identical to its input.

The true derivative there is finite. The singularity at `theta = 0` belongs to the axis-angle *parametrization*, not to the rotation, and the limit is

```
dMi = skew(v1 x dv2) / s,     s = |v1| |v2|
```

so `warpDeriv` and `warpDerivFwd` silently dropped the **entire** rotation contribution whenever they were linearized at a baseline configuration -- which is where the first iteration of an optimization and every gradient verification are evaluated. The relative error against the true derivative is exactly `1.0`, a total loss rather than a small one. It is amplified in the warp because `Si = Mi (r - Xu0) + (Xu - r)` applies `Mi` to the lever arm from the surface node out to the volume node, so the dropped term scales like `|r - Xu0| / h` against the surviving translation term and **grows under surface mesh refinement**.

The hard zero covers `theta < 1.49e-8`, but recovering `theta` through `acos` of a quantity differing from 1 by `theta^2/2` loses about half the digits, so the pristine derivative is still 16.6% wrong at `theta = 1.8e-8`, 1.2% at `1.1e-7` and `1.3e-4` at `1.2e-6`. The practically unusable band is roughly two orders of magnitude wider than the branch itself.

### Fix

Replace the axis-angle construction with the algebraically identical branch-free form. With `a = v1 x v2`, `s = |v1| |v2|`, using `|a| = s sin(theta)` and `v1.v2 = s cos(theta)`:

```
sin(theta) * skew(ahat)         = skew(a) / s
(1 - cos(theta)) * skew(ahat)^2 = skew(a)^2 / (s^2 + s (v1.v2))

Mi = I + skew(a)/s + skew(a)^2 / denom2,   denom2 = s^2 + s (v1.v2)
```

This equals the old expression for `0 <= theta < pi`, has a removable limit at `theta = 0`, and never forms a normalized axis, an `acos` or an angle -- so the `sqrt(eps)` branch and the `min(one,arg)` clamp both disappear, along with the 1.5e-8 rad primal rotation deadband. Only `theta -> pi` is now guarded, via `denom2 >= dtol * s^2` with `dtol = 1e-10`, where the rotation genuinely is not unique (anti-parallel normals, i.e. a folded surface).

`_b` and `_d` are hand-derived for the new form rather than regenerated, and are commented accordingly.

**Known trade:** `denom2 = s^2 (1 + cos(theta))` cancels as `theta -> pi`, so the new form is less accurate than `acos` there (1e-8 at `pi - 1e-4`, and `Mi` is no longer orthogonal once the `dtol` clamp engages within ~1.4e-5 rad of `pi`). That regime corresponds to a surface that has folded through itself, whereas the regime the old code mishandled is entered by every undeformed mesh. I consider this the right way round, but flagging it explicitly for reviewers.

## Expected time until merged

Not urgent in the sense of blocking a release, but it silently affects the correctness of every shape gradient linearized at a baseline mesh, so it is worth reviewing carefully rather than quickly. A week or two would be reasonable.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

**Existing regression suite -- passes unchanged, serial and parallel:**

```
$ testflo -n 1 -v test_USMesh.py
OK
Passed:  8
Failed:  0
Skipped: 8      # complex cases; no complex build in this environment
```

The stored references are reproduced exactly, e.g. `Test_o_mesh - Sum of dxs` at `52726.616916844236` to eleven significant figures. That is expected: the suite deforms the surface before differentiating, so it linearizes away from `theta = 0` where the old code was already correct to 1e-13.

**Unit-level verification of the new routines** (standalone drivers linking the primal, `_d` and `_b` against gfortran 13.3.0, over randomized `v1`, `v2` of non-unit magnitude spanning `theta = 0` to `pi`):

| Gate | Regime | Result |
|---|---|---|
| Primal, old form vs new form | 2e4 pairs, `theta < pi - 1e-4` | `1.6e-10` |
| `Mi` orthogonal, maps `v1hat -> v2hat` | same sample | `2.8e-12`, `1.2e-12` |
| `_d` vs central FD of the primal | all regimes incl. `theta = 0` | FD truncation floor |
| Transpose `<Mibar, _d(dv2)> == <_b(Mibar), dv2>` | `theta = 0`, 7e5 cases | `1.4e-11` |
| Transpose, same test | `theta -> pi` | `4.7e-10` |
| Primal recomputed inside `_d` | all `theta` bands | `0.0` exactly |
| Derivative at `v2 == v1` | `_d` norm / `_b` adjoint | `1.000000` / `(1,0,0)` |

The same transpose gate on the **pristine** routines at an undeformed baseline reads approximately `1.0`, often sign-flipped, because one side of the identity is finite and the other is an exact zero.

**To reproduce the defect on unmodified `main`:** build a mesh object, do *not* deform it, and compare `warpDerivFwd(dXs)` against a central difference of `warpMesh` over the same `dXs`. With `useRotations=True` (the default) the AD result retains only the translation part; with `useRotations=False` it is bit-identical to the rotations-on result, which is the tell. Any deformation applied first will hide it.

**Note on why the existing gates do not catch this**, since reviewers will reasonably ask why it survived so long:

* `examples/structured/dotprod.py` compares forward against reverse. Both modes are dead on the same branch, so the identity holds to machine precision while both sides are 100% wrong. A transpose gate certifies that reverse is the adjoint of forward -- mutual consistency, not correctness.
* `tests/test_USMesh.py` shears the surface (or scales it, for `inflate_cube`) and warps before differentiating, so it never linearizes at `theta = 0`.
* `verifyWarpDeriv` prints its comparison and returns nothing; the asserted quantity is a scalar sum contracted with the smooth ramp seed `numpy.linspace(0, 1.0, ndof)`, which is close to the best case for an error whose size is set by the spatial roughness of the seed.

Detecting this class of defect needs AD compared against a finite difference of the *primal*, at the base point of interest. I have not added such a test in this PR because the natural place for one is a new fixture that deliberately skips the deformation step, and I would rather agree the shape with maintainers first -- happy to add it here if you would like.

## Checklist

- [x] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted -- *no Python files are touched by this PR*
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable -- *verified that the modified `src/utils/vectorUtils.f90` is stable under the same `fprettify` settings that leave the untouched upstream routines in the file stable (`--indent 4 --line-length 132 --whitespace 3`); the two `_d`/`_b` files retain Tapenade's generated formatting, as they do on `main`*
- [x] I have run unit and regression tests which pass locally with my changes -- *`testflo` real mode 8/8; the 8 complex cases were skipped because no complex build was available locally, so CI should be the judge there*
- [ ] I have added new tests that prove my fix is effective or that my feature works -- *see the note at the end of Testing; the unit-level gates above exist as standalone drivers and I can contribute one as a proper test on request*
- [x] I have added necessary documentation -- *the new primal carries a comment block explaining the identity, the removable limit and why the old branch was fatal to AD; both derivative routines note that they are hand-derived and why*
